### PR TITLE
Mejoradas las referencias bibliograficas

### DIFF
--- a/pages/pT1/basesPage.html
+++ b/pages/pT1/basesPage.html
@@ -38,7 +38,7 @@
 								una secuencia que puede ser prácticamente infinita.<br>
 								Actualmente, la base que más se utiliza es la Decimal (10), pues se deriva de la cantidad de dedos que podemos contar en nuestras manos, aun esto, al pasar de los años la forma de escribir esto ha sido muy diferente, pues hay
 								culturales las cuales tienen una forma muy diferente de escribir a la que normalmente conocemos, esto se le denomina como “Sistema de Numeración.
-								<p class="card-text text-center"> <small class="text-muted"> Base (aritmética). (s.f.). En <i>Wikipedia</i>.Recuperado el 17 de marzo de 2020 de https://es.wikipedia.org/wiki/Base_(aritm%C3%A9tica)</small></p>
+								<p class="card-text text-center"> <small class="text-muted"> </small>(Base (aritmética), s.f).</p>
 							</p>
 						</div>
 					</div>
@@ -113,7 +113,7 @@
 												<p class="card-text card-content text-justify">
 													Aunque al ser este el más usado, se puede obviar los paréntesis y la base.
 												</p>
-											<p class="card-text text-center"> <small class="text-muted">Sistema decimal. (s.f.). En <i>EcuRed</i>.Recuperado el 17 de marzo de 2020 de https://www.ecured.cu/Sistema_decimal</small></p>
+											<p class="card-text text-center"> <small class="text-muted">(Ecured, s.f). </small></p>
 									</div>
 								</div>
 							</div>
@@ -135,7 +135,7 @@
 											<p class="card-text card-content mx-auto my-auto text-center">
 												(1100011010)<sub>2</sub>
 											</p>
-											<p class="card-text text-center"> <small class="text-muted">Sistema binario. (s.f.). En <i>EcuRed</i>.Recuperado el 17 de marzo de 2020 de https://www.ecured.cu/Sistema_binario</small></p>
+											<p class="card-text text-center"> <small class="text-muted">(Ecured, s.f).</small></p>
 									</div>
 								</div>
 							</div>
@@ -157,7 +157,7 @@
 											<p class="card-text card-content mx-auto my-auto text-center">
 												(1536711)<sub>8</sub>
 											</p>
-											<p class="card-text text-center"> <small class="text-muted">Sistema octal. (s.f.). En <i>EcuRed</i>.Recuperado el 17 de marzo de 2020 de https://www.ecured.cu/Sistema_octal</small></p>
+											<p class="card-text text-center"> <small class="text-muted">(Ecured, s.f).</small></p>
 									</div>
 								</div>
 							</div>
@@ -179,7 +179,7 @@
 											<p class="card-text card-content mx-auto my-auto text-center">
 												(CA7F)<sub>16</sub>
 											</p>
-											<p class="card-text text-center"> <small class="text-muted">Sistema hexadecimal. (s.f.). En <i>EcuRed</i>.Recuperado el 17 de marzo de 2020 de https://www.ecured.cu/Sistema_hexadecimal</small></p>
+											<p class="card-text text-center"> <small class="text-muted">(Ecured, s.f).</small></p>
 									</div>
 								</div>
 							</div>
@@ -232,7 +232,7 @@
 							<strong>6: </strong> Al final se almaceraon todos los residuos, estos son los núeros que conforman la cadena de caracteres de la conversión. Para acomodarlos, se procederá a iniciar con el último y se deberá ir progresivamente
 							acomodando los de las anteriores hasta llegar al primer residuo.<br>
 						</p>
-						<p class="card-text text-center"> <small class="text-muted">Conversión de base decimal a otro sistema de numeración. (s.f.). En <i>Sangaku Maths</i>.Recuperado el 17 de marzo de 2020 de https://www.sangakoo.com/es/temas/conversion-de-base-decimal-a-otro-sistema-de-numeracion</small></p>
+						<p class="card-text text-center"> <small class="text-muted">(Sangaku S.L, 2020).</small></p>
 					</div>
 				</div>
 			</div>
@@ -291,7 +291,7 @@
 
 			<div class="container-sm">
 				<footer>
-					<p class="card-text text-center"> <small class="text-muted">Última Actualización: 2 de Marzo, 2019</small></p>
+					<p class="card-text text-center"> <small class="text-muted">Última Actualización: 24 de Marzo, 2020</small></p>
 				</footer>
 			</div>
 

--- a/pages/pT1/historiaPage.html
+++ b/pages/pT1/historiaPage.html
@@ -37,7 +37,7 @@
 							<p class="card-text card-content text-justify">
 								Los sistemas numeración fueron creados por la necesidad del ser humano de construir casas, contar sus animales o ganados, recorrer distancias, saber cuánto duraban las estaciones y para el intercambio comercial.<br>
 								Es así como cada cultura de nuestros antepasados diseñó su propio sistema de numeración, algunos usaban los dedos, símbolos, piedras, marcas, nudos, etc.
-								<p class="card-text text-center"> <small class="text-muted">Los sistemas de numeración a lo largo de la historia.(s.f.). En <i>Sutori</i>.Recuperado el 17 de marzo de 2020 de https://www.sutori.com/story/los-sistemas-de-numeracion-a-lo-largo-de-la-historia--4Mtg35nmK8EgeJ8Fa5BJL51w</small></p>
+								<p class="card-text text-center"> <small class="text-muted">(Balboa, s.f).</small></p>
 							</p>
 						</div>
 					</div>
@@ -74,7 +74,7 @@
 								* <b>Los sistemas de numeración no posicionales o aditivos: </b>para escribir un número en este sistema, se añaden los símbolos que representan cada número sin que importe su orden, un ejemplo de este sistema es la numeración egipcia
 								y la numeración romana.<br><br>
 								* <b>Los sistemas de numeración posicionales o ponderados: </b>En este sistema importa la posición y el valor del símbolo usado para representar el número. Un ejemplo de este sistema es la numeración maya, y la numeración china.
-								<p class="card-text text-center"> <small class="text-muted">Sistema de numeración.(s.f.). En <i>Wikipedia</i>.Recuperado el 17 de marzo de 2020 de https://es.wikipedia.org/wiki/Sistema_de_numeraci%C3%B3n</small></p>
+								<p class="card-text text-center"> <small class="text-muted"> (Sistema de numeración, s.f).</small></p>
 							</p>
 						</div>
 					</div>
@@ -98,7 +98,7 @@
 								A principios del tercer milenio a.C. los egipcios disponían del primer sistema numérico en base 10 o decimal y aditivo, es uno de los sistemas de numeración más antiguos, los egipcios representaron cada número con símbolos, se dice
 								que el sistema numérico egipcio es aditivo porque para representar una cantidad se suman o adicionan los símbolos sin importar el orden, se pueden escribir de izquierda a derecha, de derecha a izquierda, de arriba abajo (o viceversa),
 								sin que esto afectara su valor, y en fracciones, usualmente solían acompañar estos números con jeroglíficos correspondiente al tipo de objeto (animales, prisioneros, vasijas, etc.).
-								<p class="card-text text-center"> <small class="text-muted">Numeración egipcia.(s.f.). En <i>Wikipedia</i>.Recuperado el 17 de marzo de 2020 de https://es.wikipedia.org/wiki/Numeraci%C3%B3n_egipcia</small></p>
+								<p class="card-text text-center"> <small class="text-muted">(Numeración egipcia, s.f).</small></p>
 							</p>
 						</div>
 					</div>
@@ -119,7 +119,7 @@
 								El punto representa la unidad, la línea es cinco, y el caracol o semilla equivale a cero. De esta combinación de símbolos se obtenían los números del 0 al 19. El valor exacto de un número se determinó por su posición vertical; al
 								subir una posición, el valor básico de la unidad se multiplicó por veinte. Es así como en el sistema de numeración maya las cantidades son agrupadas de 20 en 20. El sistema maya es un sistema posicional que se escribe de arriba abajo,
 								empezando por el orden de magnitud mayor.
-								<p class="card-text text-center"> <small class="text-muted">Los sistemas de numeración a lo largo de la historia(s.f.). En <i>Thales</i>.Recuperado el 17 de marzo de 2020 de https://thales.cica.es/rd/Recursos/rd97/Otros/SISTNUM.html</small></p>
+								<p class="card-text text-center"> <small class="text-muted">(Casado, s.f).</small></p>
 							</p>
 						</div>
 					</div>
@@ -145,7 +145,8 @@
 				<div class="row no-gutters">
 					<div class="col mx-3 my-3 text-center">
 						<img src="../../resources/rT1/numChina.jpg" class="rounded" width="600px" height="300px" alt="Numeración China">
-						<p class="card-text text-center"> <small class="text-muted">Tomada de: https://thales.cica.es/rd/Recursos/rd97/Otros/SISTNUM.html</small></p>
+						<p class="card-text text-center"> <small class="text-muted">Casado, S. (s.f). Ilustración numeración China. [Figura]. Recuperado de https://bit.ly/2xYgVh1
+</small></p>
 					</div>
 					<div class="col">
 						<div class="card-body">
@@ -153,7 +154,7 @@
 								Es un sistema decimal estricto que usa las unidades y los distintas potencias de 10. Usa la combinación de los números hasta el diez con la decena, centena, millar y decena de millar para según el principio multiplicativo representar
 								50, 700 o 3000. Los números chinos eran representados con diversos ideogramas. Es un sistema posicional, el orden de escritura se hace fundamental, se escribe de arriba debajo de izquierda a derecha y se basa en el principio
 								multiplicativo, primero el dígito (de 1 a 9), luego el lugar (10, 100...), y después el próximo dígito.
-								<p class="card-text text-center"> <small class="text-muted">Los sistemas de numeración a lo largo de la historia(s.f.). En <i>Thales</i>.Recuperado el 17 de marzo de 2020 de https://thales.cica.es/rd/Recursos/rd97/Otros/SISTNUM.html</small></p>
+								<p class="card-text text-center"> <small class="text-muted">(Casado, s.f).</small></p>
 							</p>
 						</div>
 					</div>
@@ -173,13 +174,13 @@
 								unidades y cada X representa 10 unidades más.<br>
 								Se basa en un sistema aditivo (cada signo representa un valor que se va sumando al anterior). La numeración romana posteriormente evolucionó a un sistema sustractivo, en el cual algunos signos en lugar de sumar, restan. Por ejemplo el
 								4 en la numeración etrusca se representaba como IIII (1+1+1+1), mientras que en la numeración romana moderna se representa como IV (1 restado a 5).”
-								<p class="card-text text-center"> <small class="text-muted">Numeración romana.(s.f.). En <i>Wikipedia</i>.Recuperado el 17 de marzo de 2020 de https://es.wikipedia.org/wiki/Numeraci%C3%B3n_romana</small></p>
+								<p class="card-text text-center"> <small class="text-muted">(Numeración romana, s.f).</small></p>
 							</p>
 						</div>
 					</div>
 					<div class="col mx-3 my-3 text-center text-justify">
 						<img src="../../resources/rT1/numRomana.jpg" class="rounded" width="600px" height="300px" alt="Numeración Romana">
-						<small class="text-muted">Tomada de: hhttps://thales.cica.es/rd/Recursos/rd97/Otros/SISTNUM.html</small></p>
+						<small class="text-muted">Casado, S. (s.f). Ilustración numeración romana. [Figura]. Recuperado de https://bit.ly/2xYgVh1</small></p>
 
 					</div>
 				</div>
@@ -193,7 +194,7 @@
 				<div class="row no-gutters">
 					<div class="col mx-3 my-3 text-center">
 						<img src="../../resources/rT1/numIndoarabica.PNG" class="rounded" width="600px" height="300px" alt="Numeración Indoarabica">
-						<p class="card-text text-center"> <small class="text-muted">Tomada de: https://es.wikipedia.org/wiki/N%C3%BAmeros_ar%C3%A1bigos</small></p>
+						<p class="card-text text-center"> <small class="text-muted">Wikipedia (s.f). Ilustación numeración indo-arábica. [Figura]. Recuperado de https://bit.ly/2Uwl4k5s</small></p>
 					</div>
 					<div class="col">
 						<div class="card-body">
@@ -204,7 +205,7 @@
 								El sistema indo arábigo se representa por medio de conjuntos de glifos, en la india se usaba un sistema numeral posicional base 10 con 9 glifos y se conocía el concepto del cero, representado por un punto. <br>
 								“Curiosamente, en el mundo musulmán solamente los matemáticos utilizaban el sistema de numeración arábigo hasta tiempos relativamente recientes. Los científicos usaban el sistema babilónico y los comerciantes los sistemas griego y
 								hebreo.” <br>
-								<p class="card-text text-center"> <small class="text-muted">Números arábigos.(s.f.). En <i>Wikipedia</i>.Recuperado el 17 de marzo de 2020 de https://es.wikipedia.org/wiki/N%C3%BAmeros_ar%C3%A1bigos</small></p>
+								<p class="card-text text-center"> <small class="text-muted">(Números arábigos, s.f).</small></p>
 							</p>
 						</div>
 					</div>
@@ -215,7 +216,7 @@
 
 			<div class="container-sm">
 				<footer>
-					<p class="card-text text-center"> <small class="text-muted">Última Actualización: 2 de Marzo, 2019</small></p>
+					<p class="card-text text-center"> <small class="text-muted">Última Actualización: 24 de Marzo, 2020</small></p>
 				</footer>
 			</div>
 		</div>

--- a/pages/pT1/principalT1.html
+++ b/pages/pT1/principalT1.html
@@ -245,8 +245,22 @@
 				<hr size="2px" color="black" />
 				<p>1- Jiménez, L., Gordillo, J., y Rubiano, G. (2004). <i>Teoría de números para
 						principiantes</i> (2a. ed.). Bogotá: Universidad Nacional de Colombia</p>
-				<p>2- Cid, E., Godino, J., y Batanero, C. (2002). <i>Sistemas numéricos y su 
+				<p>2- Cid, E., Godino, J., y Batanero, C. (2002). <i>Sistemas numéricos y su
 					didáctica para maestros</i>. España: Universidad de Granada</p>
+				<p>3 - Balboa P. (Sin fecha).  <i>Los sistemas de numeración a lo largo de la historia</i>.
+					Recuperado de: https://bit.ly/39mKAhb</p>
+				<p>4 - <i>Sistema de numeración</i>. (Sin fecha). En Wikipedia.
+					Recuperado el 17 de marzo de 2020 de https://bit.ly/3bryODE</p>
+				<p>5 - <i>Numeración egipcia</i>. (Sin fecha). En Wikipedia. Recuperado el 17 de marzo de 2020 de https://bit.ly/33N8MrB</p>
+				<p>6 - Casado S. (Sin fecha). <i>Los sistemas de numeración a lo largo de la historia</i>. Recuperado de: https://bit.ly/2xkR2aX</p>
+				<p>7 - <i>Numeración romana</i>. (Sin fecha). En Wikipedia. Recuperado el 17 de marzo de 2020 de https://bit.ly/2WE8l1c</p>
+				<p>8 - <i>Números arábigos</i>. (Sin fecha). En Wikipedia. Recuperado el 17 de marzo de 2020 de https://bit.ly/2J92Z6m</p>
+				<p>9 - <i> Base (aritmética).</i>(Sin fecha). En Wikipedia. Recuperado el 17 de marzo de 2020 de https://bit.ly/2Uws00B</p>
+				<p>10 - Ecured. (Sin fecha). <i>Sistema decimal.</i> Recuperado el 17 de marzo de 2020 de https://bit.ly/3agPdKX</p>
+				<p>11 - Ecured. (Sin fecha). <i>Sistema binario.</i> Recuperado el 17 de marzo de 2020 de https://www.ecured.cu/Sistema_binario</p>
+				<p>12 - Ecured. (Sin fecha). <i>Sistema octal.</i> Recuperado el 17 de marzo de 2020 de https://www.ecured.cu/Sistema_octal</p>
+				<p>13 - Ecured. (Sin fecha). <i>Sistema hexadecimal.</i> Recuperado el 17 de marzo de 2020 de https://www.ecured.cu/Sistema_hexadecimal</p>
+				<p>14 -  Sangaku S.L. (2020) <i>Conversión de base decimal a otro sistema de numeración.</i> sangakoo.com. Recuperado de https://bit.ly/39hnmZN</p>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
Ahora todas las referencias tienen formato APA. Las referencias de Wiipedia cambian un poco al resto por lo que dicen las normas APA aqui: https://normasapa.com/como-citar-referenciar-wikipedia-normas-apa/